### PR TITLE
Fixed EndpointTests bug causing visual inconsistencies.

### DIFF
--- a/.github/workflows/maven-tests.yml
+++ b/.github/workflows/maven-tests.yml
@@ -14,9 +14,9 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - name: Start MySQL container
-        run: docker run -d -p 3306:3306 --name mysql -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=book_store -e MYSQL_USER=group22 -e MYSQL_PASSWORD=password mysql/mysql-server:latest
+        run: docker run -d -p 3306:3306 --name mysql -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=book_store_test -e MYSQL_USER=group22 -e MYSQL_PASSWORD=password mysql/mysql-server:latest
       - name: Wait for MySQL to start
-        run: sleep 30s
+        run: sleep 20s
       - name: TEST with Maven
         run: mvn test
       - name: Stop MySQL container

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Note: the above command will build and run the bookstore app and database contai
 
 ## Running without Docker Compose
 
-You can run the jar file created by Maven or the Docker image separately if you want.
+You can run the jar file created by Maven or the Docker image separately if you want, make sure you are in the root project directory before executing any of these commands:
 
-- To run the jar file created by Maven: `java -jar target/4806_project-1.0.jar`
-- To run the MySQL container: `docker run -d -p 3306:3306 --name mysql -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=book_store -e MYSQL_USER=group22 -e MYSQL_PASSWORD=password mysql/mysql-server:latest`
-- To run the bookstore container: `docker run -i -t --publish 127.0.0.1:8080:8080/tcp 4806_project`
+  - To run the jar file created by Maven: `java -jar target/4806_project-1.0.jar`
+  - To run the MySQL container: `docker run -d -p 3306:3306 --name mysql -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=book_store -e MYSQL_USER=group22 -e MYSQL_PASSWORD=password -v "$(pwd)/src/main/resources/init:/docker-entrypoint-initdb.d" mysql/mysql-server:latest`
+  - To run the bookstore container: `docker run -i -t --publish 127.0.0.1:8080:8080/tcp 4806_project`
 
 ## Testing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       MYSQL_DATABASE: book_store
       MYSQL_USER: group22
       MYSQL_PASSWORD: password
+    volumes:
+      - ./src/main/resources/init:/docker-entrypoint-initdb.d
     ports:
       - "3306:3306"
     networks:

--- a/src/main/resources/application.test.properties
+++ b/src/main/resources/application.test.properties
@@ -1,0 +1,6 @@
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.datasource.url=jdbc:mysql://localhost:3306/book_store_test
+spring.datasource.username=group22
+spring.datasource.password=password
+spring.servlet.multipart.max-file-size = 100MB
+spring.servlet.multipart.max-request-size = 100MB

--- a/src/main/resources/init/create_test_db.sql
+++ b/src/main/resources/init/create_test_db.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE IF NOT EXISTS book_store_test;
+GRANT ALL ON book_store_test.* TO 'group22'@'%';

--- a/src/test/java/main/EndpointsTest.java
+++ b/src/test/java/main/EndpointsTest.java
@@ -9,7 +9,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -25,6 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@TestPropertySource(locations="classpath:application.test.properties")
 public class EndpointsTest {
 
     @Autowired
@@ -35,6 +38,15 @@ public class EndpointsTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private Environment env;
+
+    @Test
+    public void testPropertySource() {
+        String dataSourceUrl = env.getProperty("spring.datasource.url");
+        System.out.println("The value of spring.datasource.url is: " + dataSourceUrl);
+    }
 
     @Test
     public void registerNewUserAPITest() throws Exception {


### PR DESCRIPTION
- Added new application.test.properties file to be used by MockMVC.
- Added an EndpointsTest to check if we are using the proper database url defined in application.test.properties.
- Added create_test_db.sql file containing sql statements required to create a seperate database for testing inside the same MySQL container.
- Mounted the create_test_db.sql file as a docker volume inside the container, this file is then executed by MySQL Docker container entrypoint script.
- Updated docker command in README.md and github workflows maven-test.yml file.